### PR TITLE
修正 skip_route 在 Laravel 8.x 發生錯誤問題

### DIFF
--- a/src/Middleware/RequestRecorderMiddleware.php
+++ b/src/Middleware/RequestRecorderMiddleware.php
@@ -146,32 +146,24 @@ class RequestRecorderMiddleware
             return false;
         }
 
-        if(explode('.',App::VERSION())[0] == 8){ //判斷Laravel版本
-            // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
-            if (array_key_exists($routeName, $skipRoutes->toArray())) {
-                $dataSet = $skipRoutes->get($routeName)->first();
+        // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
+        if (array_key_exists($routeName, $skipRoutes->toArray())) {
+            $dataSet = $skipRoutes->get($routeName)->first();
 
-                // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
-                if (empty($dataSet['http_code']) || in_array('*', $dataSet['http_code'])) {
-                    return true;
-                }
-                if (in_array($responseCode, $dataSet['http_code'])) {
-                    return true;
-                }
+            // 當 config 中對應該路由的 http code 的設定為空
+            if (empty($dataSet['http_code'])) {
+                return true;
             }
-        }else{
-            // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
-            if (array_key_exists($routeName, $skipRoutes->toArray())) {
-                $dataSet = $skipRoutes->get($routeName)->first();
 
-                // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
-                if (empty(array_get($dataSet, 'http_code')) || in_array('*', array_get($dataSet, 'http_code'))) {
-                    return true;
-                }
+            // 當 config 中對應該路由的 http code 的設定錯誤成字串
+            // 例如: [ 'route_name' => 'index', 'http_code' => 200,400 ],
+            if(!is_array($dataSet['http_code'])){
+                return true;
+            }
 
-                if (in_array($responseCode, array_get($dataSet, 'http_code'))) {
-                    return true;
-                }
+            //當 config 中對應該路由的 http code 的設定為萬用或者有對應response code
+            if (in_array($responseCode, $dataSet['http_code']) || in_array('*', $dataSet['http_code'])) {
+                return true;
             }
         }
 

--- a/src/Middleware/RequestRecorderMiddleware.php
+++ b/src/Middleware/RequestRecorderMiddleware.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use LittleBookBoy\Request\Recorder\Models\RequestRecords;
 use Ramsey\Uuid\Uuid;
+use App;
 
 class RequestRecorderMiddleware
 {
@@ -145,32 +146,34 @@ class RequestRecorderMiddleware
             return false;
         }
 
-        // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
-        if (array_key_exists($routeName, $skipRoutes->toArray())) {
-            $dataSet = $skipRoutes->get($routeName)->first();
+        if(explode('.',App::VERSION())[0] == 8){ //判斷Laravel版本
+            // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
+            if (array_key_exists($routeName, $skipRoutes->toArray())) {
+                $dataSet = $skipRoutes->get($routeName)->first();
 
-            // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
-            if (empty($dataSet['http_code']) || in_array('*', $dataSet['http_code'])) {
-                return true;
+                // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
+                if (empty($dataSet['http_code']) || in_array('*', $dataSet['http_code'])) {
+                    return true;
+                }
+                if (in_array($responseCode, $dataSet['http_code'])) {
+                    return true;
+                }
             }
-            if (in_array($responseCode, $dataSet['http_code'])) {
-                return true;
+        }else{
+            // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
+            if (array_key_exists($routeName, $skipRoutes->toArray())) {
+                $dataSet = $skipRoutes->get($routeName)->first();
+
+                // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
+                if (empty(array_get($dataSet, 'http_code')) || in_array('*', array_get($dataSet, 'http_code'))) {
+                    return true;
+                }
+
+                if (in_array($responseCode, array_get($dataSet, 'http_code'))) {
+                    return true;
+                }
             }
         }
-
-        // // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
-        // if (array_key_exists($routeName, $skipRoutes->toArray())) {
-        //     $dataSet = $skipRoutes->get($routeName)->first();
-
-        //     // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
-        //     if (empty(array_get($dataSet, 'http_code')) || in_array('*', array_get($dataSet, 'http_code'))) {
-        //         return true;
-        //     }
-
-        //     if (in_array($responseCode, array_get($dataSet, 'http_code'))) {
-        //         return true;
-        //     }
-        // }
 
         return false;
     }

--- a/src/Middleware/RequestRecorderMiddleware.php
+++ b/src/Middleware/RequestRecorderMiddleware.php
@@ -150,14 +150,27 @@ class RequestRecorderMiddleware
             $dataSet = $skipRoutes->get($routeName)->first();
 
             // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
-            if (empty(array_get($dataSet, 'http_code')) || in_array('*', array_get($dataSet, 'http_code'))) {
+            if (empty($dataSet['http_code']) || in_array('*', $dataSet['http_code'])) {
                 return true;
             }
-
-            if (in_array($responseCode, array_get($dataSet, 'http_code'))) {
+            if (in_array($responseCode, $dataSet['http_code'])) {
                 return true;
             }
         }
+
+        // // 使用者在 config 中有匹配到目前請求路由，進入檢查 http code 的設定
+        // if (array_key_exists($routeName, $skipRoutes->toArray())) {
+        //     $dataSet = $skipRoutes->get($routeName)->first();
+
+        //     // 當 config 中對應該路由的 http code 的設定為空或萬用，所有對應該請求的路由都記錄起來
+        //     if (empty(array_get($dataSet, 'http_code')) || in_array('*', array_get($dataSet, 'http_code'))) {
+        //         return true;
+        //     }
+
+        //     if (in_array($responseCode, array_get($dataSet, 'http_code'))) {
+        //         return true;
+        //     }
+        // }
 
         return false;
     }

--- a/src/Migrations/2017_05_25_023957_request_records.php
+++ b/src/Migrations/2017_05_25_023957_request_records.php
@@ -27,13 +27,13 @@ class RequestRecords extends Migration
             // 接收到的 Header
             $table->text('request_headers')->nullable()->comment('接收到的 Header');
             // 接收到的 Request 參數
-            $table->text('request_params')->comment('接收到的 Request 參數');
+            $table->longText('request_params')->comment('接收到的 Request 參數');
             // 對應請求所回應的 Header
             $table->text('response_headers')->nullable()->comment('對應請求所回應的 Header');
             // 對應請求所回應 code
             $table->string('response_code', 4)->comment('對應請求所回應 http code');
             // 對應請求所回應的內容
-            $table->text('response_content')->nullable()->comment('對應請求所回應的內容');
+            $table->longText('response_content')->nullable()->comment('對應請求所回應的內容');
             // 請求處理狀態：若為真表示請求已處理完成，不為真表示未完成
             // $table->boolean('job_status')->default(false)->comment('請求處理狀態：若為真表示請求已處理完成，不為真表示未完成');
             // 請求來源 ip


### PR DESCRIPTION
1. RequestRecorderMiddleware 移除舊版的 array_get 方式, 直接使用 $data['http_code'] 參數, 並增加判斷 $data['http_code'] 是否為陣列.
2. 2017_05_25_023957_request_records 調整 request_params 及 response_content 欄位為 longText.